### PR TITLE
CFW Settings toggle MOD

### DIFF
--- a/source/toolbox.cpp
+++ b/source/toolbox.cpp
@@ -12008,46 +12008,34 @@ void apply_settings(char *option, int val, u8 _forced)
 	if(!strcmp(option, "cfw_settings"))
 	{
 
-	if( exist((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network.xml.org") )
+	if( exist((char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml.off") )
 		cfw_settings=1;	//enabled
-	else if( exist((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network.xml.cfw") )
+	else if( exist((char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml.on") )
 		cfw_settings=0;	//disabled
 
-			if(cfw_settings==1 && exist((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network_tool2.xml.org") )
+			if(cfw_settings==1 && exist((char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml") 
+							   && exist((char*)"/dev_rebug/vsh/module/xai_plugin.sprx"))
 			{
 				rename((char*)"/dev_rebug/vsh/module/xai_plugin.sprx",
 					(char*)"/dev_rebug/vsh/module/xai_plugin.sprx.bak");
-				rename((char*)"/dev_rebug/vsh/resource/xai_plugin.rco",
-					(char*)"/dev_rebug/vsh/resource/xai_plugin.rco.bak");
-				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network.xml",
-					(char*)"/dev_rebug/vsh/resource/explore/xmb/category_network.xml.cfw");
-				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network.xml.org",
-					(char*)"/dev_rebug/vsh/resource/explore/xmb/category_network.xml");
-				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network_tool2.xml",
-					(char*)"/dev_rebug/vsh/resource/explore/xmb/category_network_tool2.xml.cfw");
-				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network_tool2.xml.org",
-					(char*)"/dev_rebug/vsh/resource/explore/xmb/category_network_tool2.xml");
+				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml",
+					(char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml.on");
+				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml.off",
+					(char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml");
 			strcpy(status, "XMB CFW settings MOD is Disabled. The plugin will be unloaded on next boot.");
 			auto_reboot = 1;
 			}
 			else
-			if(cfw_settings==0  && exist((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network_tool2.xml.cfw")
+			if(cfw_settings==0  && exist((char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml")
 								&& exist((char*)"/dev_rebug/vsh/module/xai_plugin.sprx.bak")
-								&& exist((char*)"/dev_rebug/vsh/resource/xai_plugin.rco.bak")
 				)
 			{
 				rename((char*)"/dev_rebug/vsh/module/xai_plugin.sprx.bak",
 					(char*)"/dev_rebug/vsh/module/xai_plugin.sprx");
-				rename((char*)"/dev_rebug/vsh/resource/xai_plugin.rco.bak",
-					(char*)"/dev_rebug/vsh/resource/xai_plugin.rco");
-				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network.xml",
-					(char*)"/dev_rebug/vsh/resource/explore/xmb/category_network.xml.org");
-				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network.xml.cfw",
-					(char*)"/dev_rebug/vsh/resource/explore/xmb/category_network.xml");
-				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network_tool2.xml",
-					(char*)"/dev_rebug/vsh/resource/explore/xmb/category_network_tool2.xml.org");
-				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/category_network_tool2.xml.cfw",
-					(char*)"/dev_rebug/vsh/resource/explore/xmb/category_network_tool2.xml");
+				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml",
+					(char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml.off");
+				rename((char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml.on",
+					(char*)"/dev_rebug/vsh/resource/explore/xmb/cfw_settings.xml");
 			strcpy(status, "XMB CFW settings MOD is Enabled. The feature will be available via Network Column on XMB.");
 			auto_reboot = 1;
 			}


### PR DESCRIPTION
Suggestion to change the way CFW settings is toggled so it uses less code and has to
rename less system files, for example the rco doesnt need to be renamed, and
this way only 1 xml needs to be renamed. also only 1 extra xml needs to be
included instead of 2. It also means it will be easier for any other
modders to edit the network category in the future as the main network xmls would not be swapped. 

*a dummy/empty cfw_settings.xml needs to be included @ dev_flash/vsh/resource/explore/xmb/ for the default OFF setting, this xml will get renamed to "cfw_settings.xml.off" when it the setting gets enabled. And the standard cfw_settings.xml needs to be included at the same path but called "cfw_settings.xml.on" by default. 

Note: The sprx still gets renamed so the plugin doesn't load.
